### PR TITLE
fix misleading readme comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Pidroid uses a `config.json` file at its `./bot` path (the same path where `main
   "authentication": {
     "bot token": "",            // Bot token given by Discord
 
-    // MondoDB database
+    // MongoDB database
     "database": {
       "connection string": ""   // MongoDB connection string
     },

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Pidroid uses a `config.json` file at its `./bot` path (the same path where `main
   "authentication": {
     "bot token": "",            // Bot token given by Discord
 
-    // MySQL database
+    // MondoDB database
     "database": {
       "connection string": ""   // MongoDB connection string
     },


### PR DESCRIPTION
the example configuration in README has a comment mentioning sql database, but this has since been replaced by mongodb