### PR TITLE
Refactor expiring thread code

### DIFF
--- a/bot/client.py
+++ b/bot/client.py
@@ -97,6 +97,7 @@ class Pidroid(commands.Bot):
             'cogs.ext.tasks.guild_statistics',
             'cogs.ext.tasks.plugin_store',
             'cogs.ext.tasks.punishment_handler',
+            'cogs.ext.tasks.thread',
 
             # Error handler
             'cogs.ext.error_handler',

--- a/bot/client.py
+++ b/bot/client.py
@@ -183,7 +183,7 @@ class Pidroid(commands.Bot):
     def _remove_guild_configuration(self, guild_id: int) -> None:
         self.guild_configurations.pop(guild_id)
 
-    async def create_expiring_thread(self, message: Message, name: str, expire_timestamp: int, auto_archive_duration=60):
+    async def create_expiring_thread(self, message: Message, name: str, expire_timestamp: int, auto_archive_duration: int = 60):
         """Creates a new expiring thread"""
         thread = await message.create_thread(name, auto_archive_duration)
         await self.api.create_new_expiring_thread(thread.id, expire_timestamp)

--- a/bot/client.py
+++ b/bot/client.py
@@ -183,6 +183,11 @@ class Pidroid(commands.Bot):
     def _remove_guild_configuration(self, guild_id: int) -> None:
         self.guild_configurations.pop(guild_id)
 
+    async def create_expiring_thread(self, message: Message, name: str, expire_timestamp: int):
+        """Creates a new expiring thread"""
+        thread = await message.create_thread(name=name, auto_archive_duration=60)
+        await self.api.create_new_expiring_thread(thread.id, expire_timestamp)
+
     async def dispatch_log(self, guild: Guild, log: BaseLog):
         """Dispatches a Pidroid log to a guild channel, if applicable."""
         config = self.get_guild_configuration(guild.id)

--- a/bot/client.py
+++ b/bot/client.py
@@ -97,7 +97,7 @@ class Pidroid(commands.Bot):
             'cogs.ext.tasks.guild_statistics',
             'cogs.ext.tasks.plugin_store',
             'cogs.ext.tasks.punishment_handler',
-            'cogs.ext.tasks.thread',
+            'cogs.ext.tasks.archive_threads',
 
             # Error handler
             'cogs.ext.error_handler',

--- a/bot/client.py
+++ b/bot/client.py
@@ -183,10 +183,11 @@ class Pidroid(commands.Bot):
     def _remove_guild_configuration(self, guild_id: int) -> None:
         self.guild_configurations.pop(guild_id)
 
-    async def create_expiring_thread(self, message: Message, name: str, expire_timestamp: int):
+    async def create_expiring_thread(self, message: Message, name: str, expire_timestamp: int, auto_archive_duration=60):
         """Creates a new expiring thread"""
-        thread = await message.create_thread(name=name, auto_archive_duration=60)
+        thread = await message.create_thread(name, auto_archive_duration)
         await self.api.create_new_expiring_thread(thread.id, expire_timestamp)
+        return thread
 
     async def dispatch_log(self, guild: Guild, log: BaseLog):
         """Dispatches a Pidroid log to a guild channel, if applicable."""

--- a/bot/cogs/ext/tasks/archive_threads.py
+++ b/bot/cogs/ext/tasks/archive_threads.py
@@ -1,22 +1,14 @@
-from datetime import timedelta
-from discord import Message, NotFound
-from discord.threads import Thread
+from discord import NotFound
 from discord.ext import tasks, commands
-from discord.ext.commands.context import Context
+from discord.threads import Thread
 
-from cogs.models.categories import RandomCategory
-from cogs.utils.time import utcnow
 from client import Pidroid
 from cogs.utils.checks import is_client_pidroid
-from cogs.utils.time import timedelta_to_datetime
+from cogs.utils.time import utcnow
+
 
 class ThreadTasks(commands.Cog):
     """This class implements a cog for handling of Threads that get archived after some time."""
-
-    @commands.command()
-    async def thread(self, ctx: Context, timeout: int = timedelta_to_datetime(timedelta(seconds=30)).timestamp()):
-        message = await ctx.reply(content="here it is")
-        await self.create_expiring_thread(ctx.message  , "testNshit", timeout)
 
     def __init__(self, client: Pidroid) -> None:
         self.client = client
@@ -28,15 +20,10 @@ class ThreadTasks(commands.Cog):
         """Ensure that tasks are cancelled on cog unload."""
         self.archive_threads.cancel()
 
-    async def create_expiring_thread(self, message: Message, name: str, expire_timestamp: int):
-        thread = await message.create_thread(name=name, auto_archive_duration=60)
-        await self.api.create_new_expiring_thread(thread.id, expire_timestamp)
-
     @tasks.loop(seconds=60)
     async def archive_threads(self) -> None:
         """Archives expired threads."""
         threads_to_archive = await self.api.get_archived_threads(utcnow().timestamp())
-        print(len(threads_to_archive))
         for thread_item in threads_to_archive:
             thread_id: int = thread_item["thread_id"]
 

--- a/bot/cogs/ext/tasks/plugin_store.py
+++ b/bot/cogs/ext/tasks/plugin_store.py
@@ -5,7 +5,7 @@ from aiohttp.client_exceptions import ServerDisconnectedError
 from datetime import timedelta
 from discord.channel import TextChannel
 from discord.ext import tasks, commands # type: ignore
-from typing import Optional
+from typing import Optional, List
 
 from client import Pidroid
 from cogs.utils.checks import is_client_pidroid

--- a/bot/cogs/ext/tasks/plugin_store.py
+++ b/bot/cogs/ext/tasks/plugin_store.py
@@ -67,8 +67,7 @@ class PluginStoreTasks(commands.Cog):
                         await message.add_reaction(emoji="👎")
 
                     if self.use_threads:
-                        thread = await message.create_thread(name=f"{truncate_string(plugin.clean_title, 89)} discussion", auto_archive_duration=60)
-                        await self.api.create_new_expiring_thread(thread.id, timedelta_to_datetime(timedelta(days=7)).timestamp())
+                        self.client.create_expiring_thread(message, f"{truncate_string(plugin.clean_title, 89)} discussion", timedelta_to_datetime(timedelta(days=7)).timestamp())
         except ServerDisconnectedError:
             self.client.logger.exception("An server disconnection was encountered while trying to retrieve and publish new plugin information")
         except Exception as e:

--- a/bot/cogs/ext/tasks/thread.py
+++ b/bot/cogs/ext/tasks/thread.py
@@ -1,0 +1,67 @@
+from datetime import timedelta
+from discord import Message, NotFound
+from discord.threads import Thread
+from discord.ext import tasks, commands
+from discord.ext.commands.context import Context
+
+from cogs.models.categories import RandomCategory
+from cogs.utils.time import utcnow
+from client import Pidroid
+from cogs.utils.checks import is_client_pidroid
+from cogs.utils.time import timedelta_to_datetime
+
+class ThreadTasks(commands.Cog):
+    """This class implements a cog for handling of Threads that get archived after some time."""
+
+    @commands.command()
+    async def thread(self, ctx: Context, timeout: int = timedelta_to_datetime(timedelta(seconds=30)).timestamp()):
+        message = await ctx.reply(content="here it is")
+        await self.create_expiring_thread(ctx.message  , "testNshit", timeout)
+
+    def __init__(self, client: Pidroid) -> None:
+        self.client = client
+        self.api = self.client.api
+
+        self.archive_threads.start()
+
+    def cog_unload(self) -> None:
+        """Ensure that tasks are cancelled on cog unload."""
+        self.archive_threads.cancel()
+
+    async def create_expiring_thread(self, message: Message, name: str, expire_timestamp: int):
+        thread = await message.create_thread(name=name, auto_archive_duration=60)
+        await self.api.create_new_expiring_thread(thread.id, expire_timestamp)
+
+    @tasks.loop(seconds=60)
+    async def archive_threads(self) -> None:
+        """Archives expired threads."""
+        threads_to_archive = await self.api.get_archived_threads(utcnow().timestamp())
+        print(len(threads_to_archive))
+        for thread_item in threads_to_archive:
+            thread_id: int = thread_item["thread_id"]
+
+            try:
+                thread: Thread = await self.client.fetch_channel(thread_id)
+            except Exception as e:
+                self.client.logger.exception(f"Failure to look up a thread, ID is {thread_id}\nException: {e}")
+
+                if isinstance(e, NotFound):
+                    # If thread channel was deleted completely
+                    if e.code == 10003:
+                        self.client.logger.info("Thread channel does not exist, deleting from the database")
+                        await self.api.remove_thread(thread_item["_id"])
+                continue
+
+            await thread.edit(archived=False) # Workaround for stupid bug where archived threads can't be instantly locked
+            await thread.edit(archived=True, locked=True)
+            await self.api.remove_thread(thread_item["_id"])
+
+    @archive_threads.before_loop
+    async def before_archive_threads(self) -> None:
+        """Runs before archive_threads task to ensure that the task is allowed to run."""
+        await self.client.wait_until_ready()
+        if not is_client_pidroid(self.client):
+            self.archive_threads.cancel()
+
+async def setup(client: Pidroid) -> None:
+    await client.add_cog(ThreadTasks(client))

--- a/bot/cogs/utils/api.py
+++ b/bot/cogs/utils/api.py
@@ -7,6 +7,7 @@ import secrets
 import string
 
 from bson.objectid import ObjectId # type: ignore
+from discord import Message # type: ignore
 from discord.ext.commands.errors import BadArgument # type: ignore
 from motor.core import AgnosticCollection # type: ignore
 from pymongo.results import InsertOneResult # type: ignore
@@ -185,6 +186,11 @@ class API:
             "thread_id": thread_id,
             "expires": expire_timestamp
         })
+
+    async def create_expiring_thread(self, message: Message, name: str, expire_timestamp: int):
+        """Creates a new expiring thread"""
+        thread = await message.create_thread(name=name, auto_archive_duration=60)
+        await self.create_new_expiring_thread(thread.id, expire_timestamp)
 
     async def get_archived_threads(self, timestamp: float) -> List[dict]:
         """Returns a list of active threads which require archiving."""

--- a/bot/cogs/utils/api.py
+++ b/bot/cogs/utils/api.py
@@ -7,7 +7,6 @@ import secrets
 import string
 
 from bson.objectid import ObjectId # type: ignore
-from discord import Message # type: ignore
 from discord.ext.commands.errors import BadArgument # type: ignore
 from motor.core import AgnosticCollection # type: ignore
 from pymongo.results import InsertOneResult # type: ignore
@@ -45,8 +44,8 @@ class API:
 
     @property
     def expiring_threads(self) -> AgnosticCollection:
-        """Returns a MongoDB collection for plugin showcase threads."""
-        return self.db["Plugin_threads"]
+        """Returns a MongoDB collection for expiring threads."""
+        return self.db["Expiring_threads"]
 
     @property
     def punishments(self) -> AgnosticCollection:
@@ -186,11 +185,6 @@ class API:
             "thread_id": thread_id,
             "expires": expire_timestamp
         })
-
-    async def create_expiring_thread(self, message: Message, name: str, expire_timestamp: int):
-        """Creates a new expiring thread"""
-        thread = await message.create_thread(name=name, auto_archive_duration=60)
-        await self.create_new_expiring_thread(thread.id, expire_timestamp)
 
     async def get_archived_threads(self, timestamp: float) -> List[dict]:
         """Returns a list of active threads which require archiving."""

--- a/bot/cogs/utils/api.py
+++ b/bot/cogs/utils/api.py
@@ -43,7 +43,7 @@ class API:
         return self.db["Suggestions"]
 
     @property
-    def plugin_threads(self) -> AgnosticCollection:
+    def expiring_threads(self) -> AgnosticCollection:
         """Returns a MongoDB collection for plugin showcase threads."""
         return self.db["Plugin_threads"]
 
@@ -179,23 +179,23 @@ class API:
         ))
         return [Plugin(p) for p in response["data"]]
 
-    async def create_new_plugin_thread(self, thread_id: int, expire_timestamp: int) -> None:
-        """Creates a new plugin thread entry inside the database."""
-        await self.plugin_threads.insert_one({
+    async def create_new_expiring_thread(self, thread_id: int, expire_timestamp: int) -> None:
+        """Creates a new expiring thread entry inside the database."""
+        await self.expiring_threads.insert_one({
             "thread_id": thread_id,
             "expires": expire_timestamp
         })
 
-    async def get_archived_plugin_threads(self, timestamp: float) -> List[dict]:
-        """Returns a list of active plugin threads which require archiving."""
-        cursor = self.plugin_threads.find(
+    async def get_archived_threads(self, timestamp: float) -> List[dict]:
+        """Returns a list of active threads which require archiving."""
+        cursor = self.expiring_threads.find(
             {"expires": {"$lte": timestamp}}
         )
         return [i async for i in cursor]
 
-    async def remove_plugin_thread(self, _id: ObjectId) -> None:
-        """Removes a plugin thread entry from the database."""
-        await self.plugin_threads.delete_many({"_id": _id})
+    async def remove_thread(self, _id: ObjectId) -> None:
+        """Removes a thread entry from the database."""
+        await self.expiring_threads.delete_many({"_id": _id})
 
     """Moderation related methods"""
 


### PR DESCRIPTION
Moves code related to expiring threads out of the plugin store cog. Instead using a seperate cog, so that any cog can use them.