### PR TITLE
Fix error in create_expiring_thread

### DIFF
--- a/bot/client.py
+++ b/bot/client.py
@@ -185,7 +185,7 @@ class Pidroid(commands.Bot): # type: ignore
 
     async def create_expiring_thread(self, message: Message, name: str, expire_timestamp: int, auto_archive_duration: int = 60):
         """Creates a new expiring thread"""
-        thread = await message.create_thread(name, auto_archive_duration)
+        thread = await message.create_thread(name=name, auto_archive_duration=auto_archive_duration)
         await self.api.create_new_expiring_thread(thread.id, expire_timestamp)
         return thread
 

--- a/bot/cogs/ext/tasks/plugin_store.py
+++ b/bot/cogs/ext/tasks/plugin_store.py
@@ -67,7 +67,7 @@ class PluginStoreTasks(commands.Cog): # type: ignore
                         await message.add_reaction(emoji="👎")
 
                     if self.use_threads:
-                        self.client.create_expiring_thread(message, f"{truncate_string(plugin.clean_title, 89)} discussion", timedelta_to_datetime(timedelta(days=7)).timestamp())
+                        await self.client.create_expiring_thread(message, f"{truncate_string(plugin.clean_title, 89)} discussion", timedelta_to_datetime(timedelta(days=7)).timestamp())
         except ServerDisconnectedError:
             self.client.logger.exception("An server disconnection was encountered while trying to retrieve and publish new plugin information")
         except Exception as e:


### PR DESCRIPTION
Fixes create_expiring_thread was using positional arguments instead of named arguments.
Adds a await that was missing in plugin store threads.